### PR TITLE
Add/with context helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ module.exports = {
     elementQuerySelector: helper.elementQuerySelector,
     elementQuerySelectorAll: helper.elementQuerySelectorAll,
     stubComponent: helper.stubComponent,
+    withContext: helper.withContext,
 
     // Assertions
     assertRender: assert.renderMatch,

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -98,10 +98,9 @@ function stubComponent(tag, children, showDataProps) {
  *
  * @method withContext
  * @param {ReactComponent} Component class
- * @param {Object} props used to initialize the component
  * @return {ReactElement} react class with context setup
  **/
-function withContext(context, Component, props) {
+function withContext(context, Component) {
     var Elem = React.createFactory(Component);
     var childContextTypes = {};
 
@@ -115,7 +114,7 @@ function withContext(context, Component, props) {
             return context;
         },
         render: function () {
-            return Elem(props);
+            return Elem(this.props);
         }
     });
 }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -98,23 +98,25 @@ function stubComponent(tag, children, showDataProps) {
  *
  * @method withContext
  * @param {ReactComponent} Component class
+ * @param {Object} context the context to be passed to Component
  * @return {ReactComponent} react class with context setup
  **/
-function withContext(context, Component) {
-    var Elem = React.createFactory(Component);
+function withContext(Component, context) {
     var childContextTypes = {};
 
+    // Do not use hasOwnProperty, we need all keys from the entire prototype chain
     for (var key in context) {
         childContextTypes[key] = React.PropTypes.any;
     }
 
     return React.createClass({
+        displayName: (Component.displayName || 'Component') + ':withContext',
         childContextTypes: childContextTypes,
         getChildContext: function () {
             return context;
         },
         render: function () {
-            return Elem(this.props);
+            return React.createElement(Component, this.props);
         }
     });
 }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -94,6 +94,33 @@ function stubComponent(tag, children, showDataProps) {
 }
 
 /**
+ * Wraps component in a context creating component
+ *
+ * @method withContext
+ * @param {ReactComponent} Component class
+ * @param {Object} props used to initialize the component
+ * @return {ReactElement} react class with context setup
+ **/
+function withContext(context, Component, props) {
+    var Elem = React.createFactory(Component);
+    var childContextTypes = {};
+
+    for (var key in context) {
+        childContextTypes[key] = React.PropTypes.any;
+    }
+
+    return React.createClass({
+        childContextTypes: childContextTypes,
+        getChildContext: function () {
+            return context;
+        },
+        render: function () {
+            return Elem(props);
+        }
+    });
+}
+
+/**
  * @module helper
  **/
 module.exports = {
@@ -102,6 +129,6 @@ module.exports = {
     renderComponent: renderComponent,
     elementQuerySelector: elementQuerySelector,
     elementQuerySelectorAll: elementQuerySelectorAll,
-    stubComponent: stubComponent
-
+    stubComponent: stubComponent,
+    withContext: withContext
 };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -98,7 +98,7 @@ function stubComponent(tag, children, showDataProps) {
  *
  * @method withContext
  * @param {ReactComponent} Component class
- * @return {ReactElement} react class with context setup
+ * @return {ReactComponent} react class with context setup
  **/
 function withContext(context, Component) {
     var Elem = React.createFactory(Component);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-test",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An easy way to test your React Components (`.jsx` files).",
   "main": "index.js",
   "scripts": {

--- a/test/withContext.test.js
+++ b/test/withContext.test.js
@@ -37,7 +37,7 @@ describe('#withContext', function() {
         var NamedComponent = jsx.stubComponent('Name');
 
         assert(
-            jsx.withContext(NamedComponent).displayName === 'Name:withContext',
+            jsx.withContext(NamedComponent, {}).displayName === 'Name:withContext',
             'Expected displayName to equal "Name:withContext"'
         );
     });

--- a/test/withContext.test.js
+++ b/test/withContext.test.js
@@ -1,0 +1,34 @@
+// jsx-test
+var jsx = require('../index');
+var React = require('react/addons')
+
+describe('#withContext', function() {
+    it('gives child context', function () {
+        var ContextUser = React.createClass({
+            contextTypes: {
+                method: React.PropTypes.func
+            },
+            render: function () {
+                return React.createElement('span', null, this.context.method());
+            }
+        });
+
+        var context = {
+            method: function () {
+                return 'Awesome String!';
+            }
+        };
+
+        jsx.assertRender(jsx.withContext(context, ContextUser), {}, '<span>Awesome String!</span>');
+    });
+
+    it('passes props through context wrapper to child', function () {
+        var ContextUser = React.createClass({
+            render: function () {
+                return React.createElement('span', null, this.props.str);
+            }
+        });
+
+        jsx.assertRender(jsx.withContext({}, ContextUser), {str: 'Awesome String!'}, '<span>Awesome String!</span>');
+    });
+});

--- a/test/withContext.test.js
+++ b/test/withContext.test.js
@@ -1,6 +1,7 @@
 // jsx-test
 var jsx = require('../index');
-var React = require('react/addons')
+var React = require('react/addons');
+var assert = require('assert');
 
 describe('#withContext', function() {
     it('gives child context', function () {
@@ -19,7 +20,7 @@ describe('#withContext', function() {
             }
         };
 
-        jsx.assertRender(jsx.withContext(context, ContextUser), {}, '<span>Awesome String!</span>');
+        jsx.assertRender(jsx.withContext(ContextUser, context), {}, '<span>Awesome String!</span>');
     });
 
     it('passes props through context wrapper to child', function () {
@@ -29,6 +30,26 @@ describe('#withContext', function() {
             }
         });
 
-        jsx.assertRender(jsx.withContext({}, ContextUser), {str: 'Awesome String!'}, '<span>Awesome String!</span>');
+        jsx.assertRender(jsx.withContext(ContextUser, {}), {str: 'Awesome String!'}, '<span>Awesome String!</span>');
+    });
+
+    it('creates a readable displayName using Component.displayName', function () {
+        var NamedComponent = jsx.stubComponent('Name');
+
+        assert(
+            jsx.withContext(NamedComponent).displayName === 'Name:withContext',
+            'Expected displayName to equal "Name:withContext"'
+        );
+    });
+
+    it('creates a readable displayName even if Component did not have one', function () {
+        var UnnamedComponent = React.createClass({
+            render: function () {return null;}
+        });
+
+        assert(
+            jsx.withContext(UnnamedComponent, {}).displayName === 'Component:withContext',
+            'Expected displayName to equal "Component:withContext"'
+        );
     });
 });


### PR DESCRIPTION
@3den 

React@0.13 has a deprecation warning for `React.withContext` so I added a helper to make using mock contexts easier in testing. This will be especially useful in the future when `React.withContext` is completely removed.

Enables testing contexts by simply doing:
```js
jsx.assertRender(jsx.withContext(mockContext, MyReactComponent), props, expected);
```